### PR TITLE
Fix the pacman loader not showing, fix bugs with login/register

### DIFF
--- a/src/components/Pages/Board/index.js
+++ b/src/components/Pages/Board/index.js
@@ -8,6 +8,7 @@ import { TagsProvider } from "../../UI/BoardComponents/Tags/TagsContext";
 import { AuthProvider } from "../../Auth/AuthContext";
 import { UsersProvider } from "../../Users/UsersContext";
 import { PageWrapper } from "../../Pages";
+import { PacmanLoader } from "../../UI/Loader";
 
 class Board extends React.Component {
   static propTypes = {
@@ -51,7 +52,7 @@ class Board extends React.Component {
     return result;
   };
 
-  componentDidMount = async () => {
+  componentDidMount = () => {
     this.props.setDataSource(this.dataSource);
   };
 
@@ -513,12 +514,14 @@ class Board extends React.Component {
                 filtersActive={this.state.filters.active}
                 resetFilters={this.resetFilters}
               />
-              <Views
+              {this.props.isLoading
+              ? <PacmanLoader/>
+              : <Views
                 {...baseState}
                 kanbanFunctions={kanbanFunctions}
                 listFunctions={listFunctions}
                 filtersActive={this.state.filters.active}
-              />
+              />}
             </div>
           </TagsProvider>
         </UsersProvider>

--- a/src/components/Pages/Login/Views/Register/index.js
+++ b/src/components/Pages/Login/Views/Register/index.js
@@ -14,10 +14,6 @@ class Register extends React.Component {
     token: ""
   };
 
-  componentDidMount() {
-    this.props.handleError(this.handleError);
-  }
-
   onInputChangeHandler = (e, field) => {
     this.setState({
       fields: {

--- a/src/components/Pages/PageWrapper.jsx
+++ b/src/components/Pages/PageWrapper.jsx
@@ -2,7 +2,6 @@ import React from "react";
 import PropTypes from "prop-types";
 import { fetching, notifyToast, camelCase } from "../../utils";
 import { URLS } from "../../constants";
-import { PacmanLoader } from "../UI/Loader";
 
 const PageWrapper = Component => {
   return class extends React.Component {
@@ -15,13 +14,26 @@ const PageWrapper = Component => {
       this.state = {
         isLoading: false,
         data: null,
-        dataSource: null
       };
+      this.dataSource = null;
       this.errorHandler = e => notifyToast("error", e.message, "top-center");
       this.extraProps = {
         compFetch: this.compFetch,
-        handleError: h => (this.errorHandler = h)
+        handleError: h => (this.errorHandler = h),
+        setDataSource: d => (this.dataSource = d),
       };
+    }
+
+    componentDidMount = async () =>  {
+      this.setState({isLoading: true});
+      let data = null;
+      if (this.dataSource) {
+        data = await this.dataSource({
+          ...this.props,
+          ...this.extraProps
+        });
+      }
+      this.setState({ data, isLoading: false });
     }
 
     compFetch = async (type, action, queryParams, errorHandler) => {
@@ -44,31 +56,14 @@ const PageWrapper = Component => {
       });
     };
 
-    setDataSource = async dataSource => {
-      this.setState({ dataSource });
-      let data = null;
-      if (dataSource) {
-        data = await dataSource({
-          ...this.props,
-          ...this.extraProps
-        });
-      }
-      this.setState({ data, isLoading: false });
-    };
-
     render = () => {
-      if (this.state.isLoading) {
-        return <PacmanLoader />;
-      }
-      return (
-        <Component
+      return <Component
           data={this.state.data}
-          dataSource={this.state.dataSource}
-          setDataSource={this.setDataSource}
+          dataSource={this.dataSource}
+          isLoading={this.state.isLoading}
           {...this.extraProps}
           {...this.props}
         />
-      );
     };
   };
 };

--- a/src/utils/camelCase.js
+++ b/src/utils/camelCase.js
@@ -3,16 +3,19 @@ import _ from "lodash";
 const objectKeysToCamelCase = obj => {
   var camelCaseObject = {};
   var camelCaseArray = [];
-  _.forEach(obj, (value, key) => {
-    if (_.isPlainObject(value) || _.isArray(value)) {
-      // checks that a value is a plain object or an array - for recursive key conversion
-      value = objectKeysToCamelCase(value); // recursively update keys of any values that are also objects
-    }
-    if (_.isArray(obj)) camelCaseArray.push(value);
-    else camelCaseObject[_.camelCase(key)] = value;
-  });
-  if (_.isArray(obj)) return camelCaseArray;
-  else return camelCaseObject;
+  if(_.isObject(obj) || _.isArguments(obj)) {
+    _.forEach(obj, (value, key) => {
+      if (_.isPlainObject(value) || _.isArray(value)) {
+        // checks that a value is a plain object or an array - for recursive key conversion
+        value = objectKeysToCamelCase(value); // recursively update keys of any values that are also objects
+      }
+      if (_.isArray(obj)) camelCaseArray.push(value);
+      else camelCaseObject[_.camelCase(key)] = value;
+    });
+    if (_.isArray(obj)) return camelCaseArray;
+    else return camelCaseObject;
+  }
+  return obj;
 };
 
 export default objectKeysToCamelCase;


### PR DESCRIPTION
I reverted the change to put `setDataSource` in `state`, but if you're into keeping it in state I'll put it back.

This otherwise adds back in the pacman loader, but it needs to be moved to within whatever child of `PageWrapper` because I can't figure out how to otherwise load a component so that it gets mounted but not shown.

Also fixes some bugs in login/register.